### PR TITLE
Make mesh movable and reset GUI

### DIFF
--- a/src/GUIElement.ts
+++ b/src/GUIElement.ts
@@ -93,9 +93,14 @@ export class GUIElement extends AbstractMesh {
         this.questRect.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_RIGHT;
         this.questRect.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
         const factor = 70;
+        const topOffset = 100;
+        const leftOffset = -200;
 
-        this.rect.topInPixels = this.idx * factor;
-        this.questRect.topInPixels = this.idx * factor;
+        this.rect.topInPixels = (this.idx * factor) + topOffset;
+        this.questRect.topInPixels = (this.idx * factor) + topOffset;
+
+        this.rect.leftInPixels = leftOffset;
+        this.questRect.leftInPixels = leftOffset;
 
         this.rect.paddingTopInPixels = 2;
         this.questRect.paddingTopInPixels = 2;

--- a/src/GUIElement.ts
+++ b/src/GUIElement.ts
@@ -1,4 +1,4 @@
-import { AbstractMesh, Color3, Material, Mesh, MeshBuilder, PointerDragBehavior, StandardMaterial, Vector2, Vector3 } from "@babylonjs/core";
+import { AbstractMesh, Color3, Material, StandardMaterial, Vector2 } from "@babylonjs/core";
 import { PointerEventTypes } from "@babylonjs/core/Events/pointerEvents";
 import { Scene } from "@babylonjs/core/scene";
 import { AdvancedDynamicTexture, Control, Rectangle, TextBlock } from "@babylonjs/gui";
@@ -6,8 +6,7 @@ import { IMeshDataOptions } from "@babylonjs/core";
 
 export class GUIElement extends AbstractMesh {
     hintText: string;
-    advancedTextureHint: AdvancedDynamicTexture;
-    advancedTextureQuestion: AdvancedDynamicTexture;
+    advancedTexture: AdvancedDynamicTexture;
     scene: Scene;
     rect: Rectangle;
     questRect!: Rectangle;
@@ -15,8 +14,6 @@ export class GUIElement extends AbstractMesh {
     isOk: Boolean;
     idx!: number;
     mat!: StandardMaterial;
-    plane!: Mesh;
-    planeQuestion!: Mesh;
 
     static elementsSet: Set<string> = new Set<string>();
 
@@ -27,23 +24,7 @@ export class GUIElement extends AbstractMesh {
         super(hintText, scene);
 
         this.hintText = hintText;
-
-        this.plane = MeshBuilder.CreatePlane(`plane_${POI_mesh.name}`);
-        this.plane.position = new Vector3(10, 1, 0);
-
-        this.planeQuestion = MeshBuilder.CreatePlane(`plane_${POI_mesh.name}`);
-        this.planeQuestion.position = new Vector3(2, 1, 0);
-        
-
-        const pointerDrag = new PointerDragBehavior();
-        this.planeQuestion.addBehavior(pointerDrag);
-
-        pointerDrag.onDragObservable.add(evt => {
-            console.log("Drag");
-        })
-
-        this.advancedTextureHint = AdvancedDynamicTexture.CreateForMesh(this.plane, 200, 200);
-        this.advancedTextureQuestion = AdvancedDynamicTexture.CreateForMesh(this.planeQuestion, 200, 200);
+        this.advancedTexture = AdvancedDynamicTexture.CreateFullscreenUI("UI");
         this.scene = scene;
         this.POI_mesh = POI_mesh;
         this.rect = new Rectangle("rect");
@@ -72,27 +53,27 @@ export class GUIElement extends AbstractMesh {
     }
 
     createRectangle(text: string) {
-        // this.rect = new Rectangle("rect");
-        // this.rect.width = "200px";
-        // this.rect.height = "50px";
-        // this.rect.cornerRadius = 20;
-        // this.rect.color = "yellow";
-        // this.rect.thickness = 2;
-        // this.rect.background = "blue";
+        this.rect = new Rectangle("rect");
+        this.rect.width = "200px";
+        this.rect.height = "50px";
+        this.rect.cornerRadius = 20;
+        this.rect.color = "yellow";
+        this.rect.thickness = 2;
+        this.rect.background = "blue";
 
-        // var textBlock = new TextBlock();
-        // textBlock.text = text;
-        // textBlock.color = "white";
-        // textBlock.fontSize = "13px";
-        // textBlock.resizeToFit = true;
-        // textBlock.textWrapping = true;
+        var textBlock = new TextBlock();
+        textBlock.text = text;
+        textBlock.color = "white";
+        textBlock.fontSize = "13px";
+        textBlock.resizeToFit = true;
+        textBlock.textWrapping = true;
 
-        // this.rect.addControl(textBlock);
-        // this.rect.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_RIGHT;
-        // this.rect.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
+        this.rect.addControl(textBlock);
+        this.rect.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_RIGHT;
+        this.rect.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
 
-        // this.advancedTextureHint.addControl(this.rect);
-        // let camera = this.scene.activeCamera;
+        this.advancedTexture.addControl(this.rect);
+        let camera = this.scene.activeCamera;
 
         this.questRect = new Rectangle("questRect");
         this.questRect.width = "50px";
@@ -119,37 +100,37 @@ export class GUIElement extends AbstractMesh {
         this.rect.paddingTopInPixels = 2;
         this.questRect.paddingTopInPixels = 2;
 
-        this.advancedTextureQuestion.addControl(this.questRect);   
+        this.advancedTexture.addControl(this.questRect);   
 
-        // // Pointer Down - Start of dragging
-        // this.questRect.onPointerDownObservable.add(evt => {
-        //     // Capture initial position when drag starts
+        // Pointer Down - Start of dragging
+        this.questRect.onPointerDownObservable.add(evt => {
+            // Capture initial position when drag starts
 
-        //     this.questRect.isPointerBlocker = false;
-        //     GUIElement.pointerStart.x = this.scene.pointerX;
-        //     GUIElement.pointerStart.y = this.scene.pointerY;
-        //     GUIElement.dragged = this.questRect;
-        //     // Optionally, disable camera controls to prevent interference during dragging
-        //     camera?.detachControl();
+            this.questRect.isPointerBlocker = false;
+            GUIElement.pointerStart.x = this.scene.pointerX;
+            GUIElement.pointerStart.y = this.scene.pointerY;
+            GUIElement.dragged = this.questRect;
+            // Optionally, disable camera controls to prevent interference during dragging
+            camera?.detachControl();
 
-        //     if (this.isOk) {
-        //         if (this.rect.background === "blue") {
-        //             this.rect.background = "green";
-        //             this.questRect.background = "green";
-        //         } else {
-        //             this.rect.background = "blue";
-        //             this.questRect.background = "blue";        
-        //         }
-        //     } else {
-        //         this.rect.background = "blue";
-        //         this.questRect.background = "blue" ;                
-        //     }
-        // });
+            if (this.isOk) {
+                if (this.rect.background === "blue") {
+                    this.rect.background = "green";
+                    this.questRect.background = "green";
+                } else {
+                    this.rect.background = "blue";
+                    this.questRect.background = "blue";        
+                }
+            } else {
+                this.rect.background = "blue";
+                this.questRect.background = "blue" ;                
+            }
+        });
 
-        // this.questRect.onPointerUpObservable.add(evt => {
-        //     camera?.attachControl();
-        //     GUIElement.dragged = null;
-        // })
+        this.questRect.onPointerUpObservable.add(evt => {
+            camera?.attachControl();
+            GUIElement.dragged = null;
+        })
     }
 
     static setupMovement(scene: Scene, canvas: HTMLCanvasElement) {

--- a/src/GUIElement.ts
+++ b/src/GUIElement.ts
@@ -1,4 +1,4 @@
-import { AbstractMesh, Color3, Material, StandardMaterial, Vector2 } from "@babylonjs/core";
+import { AbstractMesh, Color3, Material, Mesh, MeshBuilder, PointerDragBehavior, StandardMaterial, Vector2, Vector3 } from "@babylonjs/core";
 import { PointerEventTypes } from "@babylonjs/core/Events/pointerEvents";
 import { Scene } from "@babylonjs/core/scene";
 import { AdvancedDynamicTexture, Control, Rectangle, TextBlock } from "@babylonjs/gui";
@@ -6,7 +6,8 @@ import { IMeshDataOptions } from "@babylonjs/core";
 
 export class GUIElement extends AbstractMesh {
     hintText: string;
-    advancedTexture: AdvancedDynamicTexture;
+    advancedTextureHint: AdvancedDynamicTexture;
+    advancedTextureQuestion: AdvancedDynamicTexture;
     scene: Scene;
     rect: Rectangle;
     questRect!: Rectangle;
@@ -14,6 +15,8 @@ export class GUIElement extends AbstractMesh {
     isOk: Boolean;
     idx!: number;
     mat!: StandardMaterial;
+    plane!: Mesh;
+    planeQuestion!: Mesh;
 
     static elementsSet: Set<string> = new Set<string>();
 
@@ -24,7 +27,23 @@ export class GUIElement extends AbstractMesh {
         super(hintText, scene);
 
         this.hintText = hintText;
-        this.advancedTexture = AdvancedDynamicTexture.CreateFullscreenUI("UI");
+
+        this.plane = MeshBuilder.CreatePlane(`plane_${POI_mesh.name}`);
+        this.plane.position = new Vector3(10, 1, 0);
+
+        this.planeQuestion = MeshBuilder.CreatePlane(`plane_${POI_mesh.name}`);
+        this.planeQuestion.position = new Vector3(2, 1, 0);
+        
+
+        const pointerDrag = new PointerDragBehavior();
+        this.planeQuestion.addBehavior(pointerDrag);
+
+        pointerDrag.onDragObservable.add(evt => {
+            console.log("Drag");
+        })
+
+        this.advancedTextureHint = AdvancedDynamicTexture.CreateForMesh(this.plane, 200, 200);
+        this.advancedTextureQuestion = AdvancedDynamicTexture.CreateForMesh(this.planeQuestion, 200, 200);
         this.scene = scene;
         this.POI_mesh = POI_mesh;
         this.rect = new Rectangle("rect");
@@ -53,27 +72,27 @@ export class GUIElement extends AbstractMesh {
     }
 
     createRectangle(text: string) {
-        this.rect = new Rectangle("rect");
-        this.rect.width = "200px";
-        this.rect.height = "50px";
-        this.rect.cornerRadius = 20;
-        this.rect.color = "yellow";
-        this.rect.thickness = 2;
-        this.rect.background = "blue";
+        // this.rect = new Rectangle("rect");
+        // this.rect.width = "200px";
+        // this.rect.height = "50px";
+        // this.rect.cornerRadius = 20;
+        // this.rect.color = "yellow";
+        // this.rect.thickness = 2;
+        // this.rect.background = "blue";
 
-        var textBlock = new TextBlock();
-        textBlock.text = text;
-        textBlock.color = "white";
-        textBlock.fontSize = "13px";
-        textBlock.resizeToFit = true;
-        textBlock.textWrapping = true;
+        // var textBlock = new TextBlock();
+        // textBlock.text = text;
+        // textBlock.color = "white";
+        // textBlock.fontSize = "13px";
+        // textBlock.resizeToFit = true;
+        // textBlock.textWrapping = true;
 
-        this.rect.addControl(textBlock);
-        this.rect.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_RIGHT;
-        this.rect.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
+        // this.rect.addControl(textBlock);
+        // this.rect.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_RIGHT;
+        // this.rect.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
 
-        this.advancedTexture.addControl(this.rect);
-        let camera = this.scene.activeCamera;
+        // this.advancedTextureHint.addControl(this.rect);
+        // let camera = this.scene.activeCamera;
 
         this.questRect = new Rectangle("questRect");
         this.questRect.width = "50px";
@@ -100,37 +119,37 @@ export class GUIElement extends AbstractMesh {
         this.rect.paddingTopInPixels = 2;
         this.questRect.paddingTopInPixels = 2;
 
-        this.advancedTexture.addControl(this.questRect);   
+        this.advancedTextureQuestion.addControl(this.questRect);   
 
-        // Pointer Down - Start of dragging
-        this.questRect.onPointerDownObservable.add(evt => {
-            // Capture initial position when drag starts
+        // // Pointer Down - Start of dragging
+        // this.questRect.onPointerDownObservable.add(evt => {
+        //     // Capture initial position when drag starts
 
-            this.questRect.isPointerBlocker = false;
-            GUIElement.pointerStart.x = this.scene.pointerX;
-            GUIElement.pointerStart.y = this.scene.pointerY;
-            GUIElement.dragged = this.questRect;
-            // Optionally, disable camera controls to prevent interference during dragging
-            camera?.detachControl();
+        //     this.questRect.isPointerBlocker = false;
+        //     GUIElement.pointerStart.x = this.scene.pointerX;
+        //     GUIElement.pointerStart.y = this.scene.pointerY;
+        //     GUIElement.dragged = this.questRect;
+        //     // Optionally, disable camera controls to prevent interference during dragging
+        //     camera?.detachControl();
 
-            if (this.isOk) {
-                if (this.rect.background === "blue") {
-                    this.rect.background = "green";
-                    this.questRect.background = "green";
-                } else {
-                    this.rect.background = "blue";
-                    this.questRect.background = "blue";        
-                }
-            } else {
-                this.rect.background = "blue";
-                this.questRect.background = "blue" ;                
-            }
-        });
+        //     if (this.isOk) {
+        //         if (this.rect.background === "blue") {
+        //             this.rect.background = "green";
+        //             this.questRect.background = "green";
+        //         } else {
+        //             this.rect.background = "blue";
+        //             this.questRect.background = "blue";        
+        //         }
+        //     } else {
+        //         this.rect.background = "blue";
+        //         this.questRect.background = "blue" ;                
+        //     }
+        // });
 
-        this.questRect.onPointerUpObservable.add(evt => {
-            camera?.attachControl();
-            GUIElement.dragged = null;
-        })
+        // this.questRect.onPointerUpObservable.add(evt => {
+        //     camera?.attachControl();
+        //     GUIElement.dragged = null;
+        // })
     }
 
     static setupMovement(scene: Scene, canvas: HTMLCanvasElement) {

--- a/src/PlaceOpacityBheavior.ts
+++ b/src/PlaceOpacityBheavior.ts
@@ -51,7 +51,7 @@ export class PlaceOpacityBehavior implements Behavior<GUIElement> {
     private checkIfRectangleAbovePOI(): void {
         if (!this.guiElement?.questRect || !this.guiElement.POI_mesh) return;
 
-        const adm = this.guiElement.advancedTexture;
+        const adm = this.guiElement.advancedTextureHint;
         const control = adm.getControlByName("questRect");
         if (control) {
             // Get the world position of the rectangle (GUI element)

--- a/src/PlaceOpacityBheavior.ts
+++ b/src/PlaceOpacityBheavior.ts
@@ -51,7 +51,7 @@ export class PlaceOpacityBehavior implements Behavior<GUIElement> {
     private checkIfRectangleAbovePOI(): void {
         if (!this.guiElement?.questRect || !this.guiElement.POI_mesh) return;
 
-        const adm = this.guiElement.advancedTextureHint;
+        const adm = this.guiElement.advancedTexture;
         const control = adm.getControlByName("questRect");
         if (control) {
             // Get the world position of the rectangle (GUI element)

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -1,4 +1,4 @@
-import { AbstractMesh, BoundingBoxGizmo, Color3, Engine, FreeCamera, HemisphericLight, Mesh, PointerDragBehavior, PointerEventTypes, RotationGizmo, ScaleGizmo, Scene, SceneLoader, UniversalCamera, UtilityLayerRenderer, Vector2, Vector3 } from '@babylonjs/core'
+import { AbstractMesh, BoundingBoxGizmo, Color3, Engine, FreeCamera, GizmoManager, HemisphericLight, Mesh, MultiPointerScaleBehavior, PointerDragBehavior, PointerEventTypes, RotationGizmo, ScaleGizmo, Scene, SceneLoader, SixDofDragBehavior, UniversalCamera, UtilityLayerRenderer, Vector2, Vector3 } from '@babylonjs/core'
 import { AdvancedDynamicTexture, Control, Rectangle, TextBlock } from '@babylonjs/gui';
 import "@babylonjs/loaders/glTF";
 import { GUIElement } from './GUIElement';
@@ -42,38 +42,58 @@ export const createSceneAsync = async (engine: Engine, canvas: HTMLCanvasElement
         rootMesh.name = modelFile;
 
         const utilLayer = new UtilityLayerRenderer(scene);
-        const boundingBoxGizmo = new BoundingBoxGizmo(new Color3(1, 1, 1), utilLayer);
-        boundingBoxGizmo.attachedMesh = rootMesh;
 
+        utilLayer.utilityLayerScene.autoClearDepthAndStencil = true;
+
+        let boundingBox = BoundingBoxGizmo.MakeNotPickableAndWrapInBoundingBox(rootMesh);
+
+        const boundingBoxGizmo = new BoundingBoxGizmo(Color3.FromHexString("#0984e3"), utilLayer);
+        // const rotateGizmo = new RotationGizmo(utilLayer);
+        boundingBoxGizmo.attachedMesh = rootMesh;
+        boundingBoxGizmo.setEnabledScaling(true, true);
+        // rotateGizmo.attachedMesh = rootMesh;
+
+        let hoverObserver = boundingBoxGizmo.onHoverStartObservable.add((evt) => {
+            console.log(evt);
+        })
+        
         boundingBoxGizmo.updateGizmoRotationToMatchAttachedMesh = false;
         boundingBoxGizmo.updateGizmoPositionToMatchAttachedMesh = true;
+        
+        let sixDofDragBehavior = new SixDofDragBehavior()
+        boundingBox.addBehavior(sixDofDragBehavior)
+        let multiPointerScaleBehavior = new MultiPointerScaleBehavior()
+        boundingBox.addBehavior(multiPointerScaleBehavior)    
 
-        let rotating = false;
-        const rightDir = new Vector3();
-        const upDir = new Vector3();
-        const sensitivity = 0.005;
+        // rotateGizmo.updateGizmoPositionToMatchAttachedMesh = true;
+        // rotateGizmo.updateGizmoRotationToMatchAttachedMesh = false;
 
-        rootMesh.isPickable = true;
+        // let rotating = false;
+        // const rightDir = new Vector3();
+        // const upDir = new Vector3();
+        // const sensitivity = 0.005;
 
-        scene.onPointerObservable.add((pointerInfo) => {
-            if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
-                if (rootMesh.getChildMeshes().includes(pointerInfo.pickInfo?.pickedMesh!)) {
-                    rotating = true;
-                    boundingBoxGizmo.attachedMesh = !boundingBoxGizmo.attachedMesh ? rootMesh : null;
-                    camera.detachControl();
-                }
-            } else if (pointerInfo.type === PointerEventTypes.POINTERUP && rotating) {
-                rotating = false;
-                camera.attachControl();
-            } else if (pointerInfo.type === PointerEventTypes.POINTERMOVE && rotating) {
-                const matrix = camera.getWorldMatrix();
-                rightDir.copyFromFloats(matrix.m[0], matrix.m[1], matrix.m[2]);
-                upDir.copyFromFloats(matrix.m[4], matrix.m[5], matrix.m[6]);
+        // rootMesh.isPickable = true;
 
-                rootMesh.rotateAround(rootMesh.position, rightDir, pointerInfo.event.movementY * -1 * sensitivity);
-                rootMesh.rotateAround(rootMesh.position, upDir, pointerInfo.event.movementX * -1 * sensitivity);
-            }
-        });
+        // scene.onPointerObservable.add((pointerInfo) => {
+        //     if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
+        //         if (rootMesh.getChildMeshes().includes(pointerInfo.pickInfo?.pickedMesh!)) {
+        //             rotating = true;
+        //             boundingBoxGizmo.attachedMesh = !boundingBoxGizmo.attachedMesh ? rootMesh : null;
+        //             camera.detachControl();
+        //         }
+        //     } else if (pointerInfo.type === PointerEventTypes.POINTERUP && rotating) {
+        //         rotating = false;
+        //         camera.attachControl();
+        //     } else if (pointerInfo.type === PointerEventTypes.POINTERMOVE && rotating) {
+        //         const matrix = camera.getWorldMatrix();
+        //         rightDir.copyFromFloats(matrix.m[0], matrix.m[1], matrix.m[2]);
+        //         upDir.copyFromFloats(matrix.m[4], matrix.m[5], matrix.m[6]);
+
+        //         rootMesh.rotateAround(rootMesh.position, rightDir, pointerInfo.event.movementY * -1 * sensitivity);
+        //         rootMesh.rotateAround(rootMesh.position, upDir, pointerInfo.event.movementX * -1 * sensitivity);
+        //     }
+        // });
 
         const POI_meshes = result.meshes.filter(mesh => mesh.name.startsWith("POI"));
         console.log(POI_meshes);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -45,7 +45,7 @@ export const createSceneAsync = async (engine: Engine, canvas: HTMLCanvasElement
 
         utilLayer.utilityLayerScene.autoClearDepthAndStencil = true;
 
-        let boundingBox = BoundingBoxGizmo.MakeNotPickableAndWrapInBoundingBox(rootMesh);
+        // let boundingBox = BoundingBoxGizmo.MakeNotPickableAndWrapInBoundingBox(rootMesh as Mesh);
 
         const boundingBoxGizmo = new BoundingBoxGizmo(Color3.FromHexString("#0984e3"), utilLayer);
         // const rotateGizmo = new RotationGizmo(utilLayer);
@@ -57,43 +57,13 @@ export const createSceneAsync = async (engine: Engine, canvas: HTMLCanvasElement
             console.log(evt);
         })
         
-        boundingBoxGizmo.updateGizmoRotationToMatchAttachedMesh = false;
+        boundingBoxGizmo.updateGizmoRotationToMatchAttachedMesh = true;
         boundingBoxGizmo.updateGizmoPositionToMatchAttachedMesh = true;
         
         let sixDofDragBehavior = new SixDofDragBehavior()
-        boundingBox.addBehavior(sixDofDragBehavior)
+        rootMesh.addBehavior(sixDofDragBehavior)
         let multiPointerScaleBehavior = new MultiPointerScaleBehavior()
-        boundingBox.addBehavior(multiPointerScaleBehavior)    
-
-        // rotateGizmo.updateGizmoPositionToMatchAttachedMesh = true;
-        // rotateGizmo.updateGizmoRotationToMatchAttachedMesh = false;
-
-        // let rotating = false;
-        // const rightDir = new Vector3();
-        // const upDir = new Vector3();
-        // const sensitivity = 0.005;
-
-        // rootMesh.isPickable = true;
-
-        // scene.onPointerObservable.add((pointerInfo) => {
-        //     if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
-        //         if (rootMesh.getChildMeshes().includes(pointerInfo.pickInfo?.pickedMesh!)) {
-        //             rotating = true;
-        //             boundingBoxGizmo.attachedMesh = !boundingBoxGizmo.attachedMesh ? rootMesh : null;
-        //             camera.detachControl();
-        //         }
-        //     } else if (pointerInfo.type === PointerEventTypes.POINTERUP && rotating) {
-        //         rotating = false;
-        //         camera.attachControl();
-        //     } else if (pointerInfo.type === PointerEventTypes.POINTERMOVE && rotating) {
-        //         const matrix = camera.getWorldMatrix();
-        //         rightDir.copyFromFloats(matrix.m[0], matrix.m[1], matrix.m[2]);
-        //         upDir.copyFromFloats(matrix.m[4], matrix.m[5], matrix.m[6]);
-
-        //         rootMesh.rotateAround(rootMesh.position, rightDir, pointerInfo.event.movementY * -1 * sensitivity);
-        //         rootMesh.rotateAround(rootMesh.position, upDir, pointerInfo.event.movementX * -1 * sensitivity);
-        //     }
-        // });
+        rootMesh.addBehavior(multiPointerScaleBehavior)    
 
         const POI_meshes = result.meshes.filter(mesh => mesh.name.startsWith("POI"));
         console.log(POI_meshes);


### PR DESCRIPTION
* Use SixDofDragBehavior to make the root mesh movable.
* Reset back the GUI because using 3D GUI has a worse experience in AR mode. There is no realistic way to prevent the 3d model clipping into the mesh. 